### PR TITLE
Move program to ~/.local/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,25 +30,30 @@ all:
 
 
 install: src/budg.py src/defaultplan.ini
+
 	# Creating directories...
+	mkdir -p ~/.local/bin
 	mkdir -p ~/.config/budg
-	mkdir -p ~/bin
+
 	# Copying program...
-	cp src/budg.py ~/bin/budg
-	chmod u+x ~/bin/budg
+	cp src/budg.py ~/.local/bin/budg
+	chmod u+x ~/.local/bin/budg
+
 	# Copying config...
 	cp src/defaultplan.ini ~/.config/budg/defaultplan.ini
-	# Install Complete. (add ~/bin to PATH)
+
+	# Install Complete.
 
 
 clean:
 	# Removing budg...
-	rm ~/bin/budg 
+	rm ~/.local/bin/budg 
 	rm -r ~/.config/budg
+
 	# budg uninstalled
 
 
-clean-bin: ~/bin/budg
+clean-bin: ~/.local/bin/budg
 	# removing budg...
-	rm ~/bin/budg
+	rm ~/.local/bin/budg
 	# budg removed

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ make install
 # Install Complete
 ```
 
-This script will copy the python file to `~/bin/budg` and make it executable. You must add `~/bin` to your path variable if you want to call `budg` from the command line.
+This script will copy the python file to `~/.local/bin/budg` and make it executable.
 
 ### Uninstallation
 

--- a/src/budg.py
+++ b/src/budg.py
@@ -118,18 +118,18 @@ def readFile():
 
     filedata = configparser.ConfigParser()
 
-    # if config file already exists
+    # if user config file exists
     if os.path.isfile(userconfig):
         filedata.read(userconfig)
 
-    # if config file does not exist
+    # user config does not exist, so try default config
+    elif os.path.isfile(defaultconfig):
+        filedata.read(defaultconfig)
+
+    # no config exists
     else:
-        # use default budget, if present
-        if os.path.isfile(defaultconfig):
-            filedata.read(defaultconfig)
-        else:
-            print("No config is found. Please create one in ~/.config/budg/")
-            exit(2)
+        print("No config is found. Please create one in ~/.config/budg/")
+        exit(2)
 
     return filedata
 


### PR DESCRIPTION
This will move the installation of the program from ~/bin to ~/.local/bin. This way, users will not have to add anything to their path in order to use budg.