### PR TITLE
move plans to user's Documents folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This tool is meant to make budgets simpler by removing the need for spreadsheets
     - [Uninstallation](#uninstallation)
   - [Usage](#usage)
     - [Plans](#plans)
-      - [~/.config/budg/defaultplan.ini](#configbudgdefaultplanini)
-      - [~/.config/budg/plan.ini](#configbudgplanini)
+      - [~/Documents/budg/defaultplan.ini](#documentsbudgdefaultplanini)
+      - [~/Documents/budg/plan.ini](#documentsbudgplanini)
     - [Budgits](#budgits)
   - [The 50/20/30 Plan](#the-502030-plan)
     - [Necessities - 50%](#necessities---50)
@@ -45,7 +45,7 @@ This script will copy the python file to `~/.local/bin/budg` and make it executa
 
 You can also use `install.sh -u` to remove all traces of budg from your system.
 
-Deletes the python file in `~/.local/bin` and the entire budg directory in `~/.config`.
+Deletes the python file in `~/.local/bin` and the entire budg directory in `~/Documents`.
 **Make sure to copy your `plan.ini` file somewhere else if you want to save it!**
 
 ```text
@@ -72,21 +72,21 @@ Using budg is easy, but there are a few things you need to know in order to make
 
 Budg uses _plans_ to divide your income into categories. A [_plan_](#plans) is a set of rules that outlines your budget. Budg divides your income into weighted categories as defined by your plan. The result of this division is called a [_budgit_](#budgits).
 
-You can change your plan by modifying `~/.config/budg/plan.ini`.
+You can change your plan by modifying `~/Documents/budg/plan.ini`.
 
 ### Plans
 
-Plans are documents that outline your budget. They tell budg how you want your money to be spent. These documents are stored in `~/.config/budg/`. The installer (`make install`) will create a default plan file for you.
+Plans are documents that outline your budget. They tell budg how you want your money to be spent. These documents are stored in `~/Documents/budg/`. The installer (`make install`) will create a default plan file for you.
 
-#### ~/.config/budg/defaultplan.ini
+#### ~/Documents/budg/defaultplan.ini
 
-This file is in the budg repository. The installation script copies this file to `~/.config/budg/defaultplan.ini`. It is a general implementation of [the 50/20/30 plan](#the-502030-plan).
+This file is in the budg repository. The installation script copies this file to `~/Documents/budg/defaultplan.ini`. It is a general implementation of [the 50/20/30 plan](#the-502030-plan).
 
-#### ~/.config/budg/plan.ini
+#### ~/Documents/budg/plan.ini
 
-`~/.config/budg/plan.ini` is an outline of your budget. It contains all of the information needed to figure out where your money belongs. Plans are the key to budgeting; deciding where your money belongs before you spend it is what brings you financial security and peace of mind.
+`~/Documents/budg/plan.ini` is an outline of your budget. It contains all of the information needed to figure out where your money belongs. Plans are the key to budgeting; deciding where your money belongs before you spend it is what brings you financial security and peace of mind.
 
-Plans are `ini` files and are stored inside your home directory (inside the path `~/.config/budg/`). : `defaultplan.ini` and `plan.ini`.
+Plans are `ini` files and are stored inside your home directory (inside the path `~/Documents/budg/`). : `defaultplan.ini` and `plan.ini`.
 
 ### Budgits
 

--- a/budg/budg.py
+++ b/budg/budg.py
@@ -24,9 +24,14 @@
 
 # imports
 import configparser
-import os.path
+import os
 import sys
 import math
+
+# CONSTANTS
+PLAN_DIRECTORY = os.path.join(os.path.expanduser("~"), "Documents", "budg")
+USER_PLAN_FILENAME = "plan.ini"
+DEFAULT_PLAN_FILENAME = "defaultplan.ini"
 
 
 # function that handles input errors
@@ -107,30 +112,22 @@ def printBudgit(budgit):
     return total
 
 
-# look in the default budgit plan location and parse a plan.ini file there
-# File -> ConfigParser
-def readFile():
+def readFile(
+    directory: os.PathLike = PLAN_DIRECTORY,
+    user_filename: os.PathLike = USER_PLAN_FILENAME,
+    default_filename: os.PathLike = DEFAULT_PLAN_FILENAME,
+) -> configparser.ConfigParser:
+    """Parses data from plan file"""
 
-    # create vars
-    userhome = os.path.expanduser("~")
-    userconfig = os.path.join(userhome, ".config/budg/plan.ini")
-    defaultconfig = os.path.join(userhome, ".config/budg/defaultplan.ini")
+    file_path = os.path.join(directory, user_filename)
+    if not os.path.isfile(file_path):
+        file_path = os.path.join(directory, default_filename)
+        if not os.path.isfile(file_path):
+            print(f"No config found. Please create one in '{directory}'.")
+            exit(2)
 
     filedata = configparser.ConfigParser()
-
-    # if user config file exists
-    if os.path.isfile(userconfig):
-        filedata.read(userconfig)
-
-    # user config does not exist, so try default config
-    elif os.path.isfile(defaultconfig):
-        filedata.read(defaultconfig)
-
-    # no config exists
-    else:
-        print("No config is found. Please create one in ~/.config/budg/")
-        exit(2)
-
+    filedata.read(file_path)
     return filedata
 
 

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@
 ## globals
 EXE_DIR_LOCATION="${HOME}/.local/bin"
 EXE_LOCATION="${EXE_DIR_LOCATION}/budg"
-PLAN_DIR_LOCATION="${HOME}/.config/budg"
+PLAN_DIR_LOCATION="${HOME}/Documents/budg"
 # dependencies
 EXE_SRC_LOCATION="./budg/budg.py"
 DEFAULTPLAN_SRC_LOCATION="./budg/defaultplan.ini"


### PR DESCRIPTION
type: enhancement

Keeping plans in .config meant that the user had to make hidden files and folders visible in order to work on their budget. This was not ideal.
I moved the directory where plans are kept to Documents in the user's home directory. Also improved the readFile function by getting rid of some unneccessary variables and reorganizing the order of execution. It will now make sure the plan file exists before initiating the ConfigParser. Added better documentation with typehints and docstring.

re: #25 Move plans to Documents